### PR TITLE
resolving problem with INTER_NEAREST

### DIFF
--- a/main.py
+++ b/main.py
@@ -112,8 +112,8 @@ def data_augmentation(input_image, output_image):
         angle = random.uniform(-1*args.rotation, args.rotation)
     if args.rotation:
         M = cv2.getRotationMatrix2D((input_image.shape[1]//2, input_image.shape[0]//2), angle, 1.0)
-        input_image = cv2.warpAffine(input_image, M, (input_image.shape[1], input_image.shape[0]), flags=INTER_NEAREST)
-        output_image = cv2.warpAffine(output_image, M, (output_image.shape[1], output_image.shape[0]), flags=INTER_NEAREST)
+        input_image = cv2.warpAffine(input_image, M, (input_image.shape[1], input_image.shape[0]), flags=cv2.INTER_NEAREST)
+        output_image = cv2.warpAffine(output_image, M, (output_image.shape[1], output_image.shape[0]), flags=cv2.INTER_NEAREST)
 
     return input_image, output_image
 


### PR DESCRIPTION
When executing the following command:
python main.py --num_epochs 10 --mode train --class_balancing True --dataset CamVid --batch_size 1 --num_val_images 20 --h_flip True --v_flip True --rotation 359 --model DeepLabV3_plus-Res50

The program threw the error below:
***** Begin training *****
Dataset --> CamVid
Model --> DeepLabV3_plus-Res50
Crop Height --> 512
Crop Width --> 512
Num Epochs --> 10
Batch Size --> 1
Num Classes --> 32
Data Augmentation:
	Vertical Flip --> True
	Horizontal Flip --> True
	Brightness Alteration --> None
	Rotation --> 359.0

Traceback (most recent call last):
  File "main.py", line 291, in <module>
    input_image, output_image = data_augmentation(input_image, output_image)
  File "main.py", line 120, in data_augmentation
    input_image = cv2.warpAffine(input_image, M, (input_image.shape[1], input_image.shape[0]), flags=INTER_NEAREST)
NameError: name 'INTER_NEAREST' is not defined

###########
I added cv2. before INTER_NEAREST and the error disappeared.

OpenCV version is 3.4.1
Python 3.5