### PR TITLE
Fixed pool_scale typo FRRN-B

### DIFF
--- a/models/FRRN.py
+++ b/models/FRRN.py
@@ -188,7 +188,7 @@ def build_frrn(inputs, num_classes, preset_model='FRRN-A'):
         # Upsampling Path 
         #####################
         pool_stream = Unpooling(pool_stream, 2)
-        pool_stream, res_stream = FullResolutionResidualUnit(pool_stream=pool_stream, res_stream=res_stream, n_filters_3=192, n_filters_1=32, pool_scale=17)
+        pool_stream, res_stream = FullResolutionResidualUnit(pool_stream=pool_stream, res_stream=res_stream, n_filters_3=192, n_filters_1=32, pool_scale=16)
         pool_stream, res_stream = FullResolutionResidualUnit(pool_stream=pool_stream, res_stream=res_stream, n_filters_3=192, n_filters_1=32, pool_scale=16)
 
         pool_stream = Unpooling(pool_stream, 2)


### PR DESCRIPTION
fixing pool_scale typo to solve error message: 

```
InvalidArgumentError (see above for traceback): ConcatOp : Dimensions of inputs should match: shape[0] = [1,384,32,32] vs. shape[1] = [1,32,30,30]
```