### PR TITLE
docs: fix simple typo, trainble -> trainable

### DIFF
--- a/frontends/mobilenet_base.py
+++ b/frontends/mobilenet_base.py
@@ -435,7 +435,7 @@ def training_scope(is_training=True,
      with tf.contrib.slim.arg_scope(mobilenet.training_scope()):
        logits, endpoints = mobilenet_v2.mobilenet(input_tensor)
 
-     # the network created will be trainble with dropout/batch norm
+     # the network created will be trainable with dropout/batch norm
      # initialized appropriately.
   Args:
     is_training: if set to False this will ensure that all customizations are


### PR DESCRIPTION
There is a small typo in frontends/mobilenet_base.py.

Should read `trainable` rather than `trainble`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md